### PR TITLE
Implementing disabled behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dcmetrics "github.com/deliverycenter/dc.libs.metrics.golang"
 ## Usage
 The first step to use the package is to call the function `Setup`. This is where the global parameters for the logger will be set and used in every metrics call.
 
-```
+```go
 err := dcmetrics.Setup("GOOGLE_PROJECT_ID", "PUBSUB_TOPIC_NAME", "DEVELOPMENT", "MY_PACKAGE", dcmetrics.Metrics{
 	Direction:        "INCOMING",
 	SourceType:       "PROVIDER",
@@ -26,7 +26,7 @@ err := dcmetrics.Setup("GOOGLE_PROJECT_ID", "PUBSUB_TOPIC_NAME", "DEVELOPMENT", 
 
 After the call to `Setup`, the logging functions can be used: `Debug()`, `Info()`, `Warn()`, `Error()`.
 
-```
+```go
 dcmetrics.Info("request published", dcmetrics.Metrics{
 	SourceName:        "PROVIDER_NAME",
 	Action:            "REQUEST_PUBLISHED",
@@ -36,3 +36,11 @@ dcmetrics.Info("request published", dcmetrics.Metrics{
 	ExtRootResourceID: "abcde",
 })
 ```
+
+### Disable logs
+
+If you need to disable the package behavior (for testing, for example), you can use:
+
+```go
+dcmetrics.Disable()
+``` 

--- a/exported.go
+++ b/exported.go
@@ -19,6 +19,12 @@ func Setup(googleProjectId string, pubSubTopicName string, environment string, c
 	return nil
 }
 
+func Disable() {
+	lg = &Logger{
+		disabled: true,
+	}
+}
+
 // Debug logs a message at level Debug.
 func Debug(message string, metrics Metrics) {
 	lg.Debug(message, metrics)

--- a/logger.go
+++ b/logger.go
@@ -15,6 +15,7 @@ type Logger struct {
 	caller         string
 	client         *dcpubsub.PubSub
 	metricsDefault Metrics
+	disabled       bool
 }
 
 func (l *Logger) Debug(message string, metrics Metrics) {
@@ -35,6 +36,10 @@ func (l *Logger) Error(message string, metrics Metrics) {
 
 // Log logs a message to both stdout and metrics API
 func (l *Logger) log(level string, message string, metrics Metrics) {
+	if l.disabled {
+		return
+	}
+
 	metrics.Level = level
 	metrics.Message = message
 


### PR DESCRIPTION
This PR adds the `Disable()` function, that can be used to disable the libs functionality. This is can be useful to avoid errors in test environments.