### PR TITLE
feat: use levels when printing to stdout

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -70,7 +70,16 @@ func (l *Logger) logToStdout(metrics Metrics) {
 		"IntStoreId":        metrics.IntStoreID,
 		"ErrorCode":         metrics.ErrorCode,
 	})
-	logger.Info(metrics.Message)
+	switch metrics.level {
+	case "DEBUG":
+		logger.Debug(metrics.Message)
+	case "WARN":
+		logger.Warn(metrics.Message)
+	case "ERROR":
+		logger.Error(metrics.Message)
+	default:
+		logger.Info(metrics.Message)
+	}
 }
 
 func (l *Logger) logToMetricsApi(metrics Metrics) {


### PR DESCRIPTION
I couldn't test it yet, so I'd like to know from reviewers if it's safe to merge such a simple change:

Why?
* gcloud log explorer entries are not themed accordingly to log level;

How?
* switch based on metrics.level in `logToStdout` and use different logrus methods