### PR TITLE
fix: wrong metrics struct field name

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -70,7 +70,7 @@ func (l *Logger) logToStdout(metrics Metrics) {
 		"IntStoreId":        metrics.IntStoreID,
 		"ErrorCode":         metrics.ErrorCode,
 	})
-	switch metrics.level {
+	switch metrics.Level {
 	case "DEBUG":
 		logger.Debug(metrics.Message)
 	case "WARN":


### PR DESCRIPTION
Due to PLT delay, the language server didn't accuse this error. Sorry 🙇🏼‍♂️ 